### PR TITLE
ES6 module syntax fixes

### DIFF
--- a/window-corner-preview@fabiomereu.it/extension.js
+++ b/window-corner-preview@fabiomereu.it/extension.js
@@ -21,6 +21,7 @@ const Slider = imports.ui.slider;
 const PanelMenu = imports.ui.panelMenu;
 const PopupMenu = imports.ui.popupMenu;
 const Clutter = imports.gi.Clutter;
+const Util = imports.misc.util;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
@@ -776,7 +777,7 @@ const CWindowCornerPreviewMenu = new Lang.Class({
     },
 
     _onSettings: function () {
-        Main.Util.trySpawnCommandLine("gnome-shell-extension-prefs window-corner-preview@fabiomereu.it");
+        Util.trySpawnCommandLine("gnome-shell-extension-prefs window-corner-preview@fabiomereu.it");
     },
 
     // Update windows list and other menus before menu pops up

--- a/window-corner-preview@fabiomereu.it/prefs.js
+++ b/window-corner-preview@fabiomereu.it/prefs.js
@@ -11,8 +11,8 @@ const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 const Convenience = Me.imports.convenience;
 
-const SETTING_BEHAVIOR_MODE = "behavior-mode";
-const SETTING_FOCUS_HIDDEN = "focus-hidden";
+var SETTING_BEHAVIOR_MODE = "behavior-mode";
+var SETTING_FOCUS_HIDDEN = "focus-hidden";
 
 function _strong(text) {
   return "<b>" + _(text) + "</b>";


### PR DESCRIPTION
Instead of using Main's import of misc.Util, import directly. Avoids ES6 module warning.

Also use `var` instead of `const` for exported properties.