### PR TITLE
Port to GNOME 3.34

### DIFF
--- a/window-corner-preview@fabiomereu.it/extension.js
+++ b/window-corner-preview@fabiomereu.it/extension.js
@@ -96,7 +96,7 @@ function previewLastWindow(preview) {
             // I don't know exactly the reason, but some windows
             // do not get shown properly without putting this on async
             // The thumbnail seems not to be ready yet
-            Mainloop.timeout_add(100, function () {
+            Mainloop.timeout_add(100, () => {
                 preview.window = anyWindow;
                 preview.show();
             });
@@ -108,20 +108,20 @@ function previewLastWindow(preview) {
     // the array is already filled
     const windows = getMetawindows();
     if (windows.length) {
-        windows.forEach(function (window) {
+        windows.forEach((window) => {
             shouldBePreviewed(window);
         });
     }
     else {
 
-        getWorkspaces().forEach(function (workspace) {
-            signals.tryConnectAfter(workspace, "window-added", function (workspace, window) {
+        getWorkspaces().forEach((workspace) => {
+            signals.tryConnectAfter(workspace, "window-added", (workspace, window) => {
                 shouldBePreviewed(window);
             });
         });
 
         const TIMEOUT = 10000;
-        timer = Mainloop.timeout_add(TIMEOUT, function () {
+        timer = Mainloop.timeout_add(TIMEOUT, () => {
             // In case the last window previewed could not be found, stop listening
             done = true;
             signals.disconnectAll();

--- a/window-corner-preview@fabiomereu.it/indicator.js
+++ b/window-corner-preview@fabiomereu.it/indicator.js
@@ -1,7 +1,7 @@
 "use strict";
 
 // Global modules
-const Lang = imports.lang;
+const GObject = imports.gi.GObject;
 const St = imports.gi.St;
 const Util = imports.misc.util;
 const PanelMenu = imports.ui.panelMenu;
@@ -26,21 +26,18 @@ const MAX_CROP_RATIO = Preview.MAX_CROP_RATIO;
 const DEFAULT_ZOOM = Preview.DEFAULT_ZOOM;
 const DEFAULT_CROP_RATIO = Preview.DEFAULT_CROP_RATIO;
 
-var WindowCornerIndicator = new Lang.Class({
+var WindowCornerIndicator = GObject.registerClass(class WindowCornerIndicator extends PanelMenu.Button {
 
-    Name: "WindowCornerPreview.indicator",
-    Extends: PanelMenu.Button,
-
-    _init: function() {
-        this.parent(null, "WindowCornerPreview.indicator");
-    },
+    _init() {
+        super._init(null, "WindowCornerPreview.indicator");
+    }
 
     // Handler to turn preview on / off
-    _onMenuIsEnabled: function(item) {
+    _onMenuIsEnabled(item) {
         (item.state) ? this.preview.show() : this.preview.hide();
-    },
+    }
 
-    _updateSliders: function() {
+    _updateSliders() {
         this.menuZoom.value = this.preview.zoom;
         this.menuZoomLabel.label.set_text("Monitor Zoom:  " + Math.floor(this.preview.zoom * 100).toString() + "%");
 
@@ -48,65 +45,65 @@ var WindowCornerIndicator = new Lang.Class({
         this.menuRightCrop.value = this.preview.rightCrop;
         this.menuTopCrop.value = this.preview.topCrop;
         this.menuBottomCrop.value = this.preview.bottomCrop;
-    },
+    }
 
-    _onZoomChanged: function(source, value) {
+    _onZoomChanged(source, value) {
         this.preview.zoom = value;
         this._updateSliders();
         this.preview.emit("zoom-changed");
-    },
+    }
 
-    _onLeftCropChanged: function(source, value) {
+    _onLeftCropChanged(source, value) {
         this.preview.leftCrop = value;
         this._updateSliders();
         this.preview.emit("crop-changed");
-    },
+    }
 
-    _onRightCropChanged: function(source, value) {
+    _onRightCropChanged(source, value) {
         this.preview.rightCrop = value;
         this._updateSliders();
         this.preview.emit("crop-changed");
-    },
+    }
 
-    _onTopCropChanged: function(source, value) {
+    _onTopCropChanged(source, value) {
         this.preview.topCrop = value;
         this._updateSliders();
         this.preview.emit("crop-changed");
-    },
+    }
 
-    _onBottomCropChanged: function(source, value) {
+    _onBottomCropChanged(source, value) {
         this.preview.bottomCrop = value;
         this._updateSliders();
         this.preview.emit("crop-changed");
-    },
+    }
 
-    _onClearCropActivate: function(source) {
+    _onClearCropActivate(source) {
         this.preview.topCrop = 0.0;
         this.preview.leftCrop = 0.0;
         this.preview.rightCrop = 0.0;
         this.preview.bottomCrop = 0.0;
         this._updateSliders();
         this.preview.emit("crop-changed");
-    },
+    }
 
-    _onCornerActivate: function(source, event, corner) {
+    _onCornerActivate(source, event, corner) {
         this.preview.corner = corner;
         this._updateSliders();
         this.preview.emit("corner-changed");
-    },
+    }
 
-    _onSettings: function() {
+    _onSettings() {
         Util.trySpawnCommandLine("gnome-shell-extension-prefs window-corner-preview@fabiomereu.it");
-    },
+    }
 
-    _onWindowActivate: function() {
+    _onWindowActivate() {
         if (this.preview.window) {
             this.preview.window.activate(global.get_current_time());
         }
-    },
+    }
 
     // Update windows list and other menus before menu pops up
-    _onUserTriggered: function() {
+    _onUserTriggered() {
         this.menuIsEnabled.setToggleState(this.preview.visible);
         this.menuIsEnabled.actor.reactive = this.preview.window;
         this.menuActivate.actor.visible = this.preview.visible;
@@ -132,25 +129,25 @@ var WindowCornerIndicator = new Lang.Class({
         );
         this._updateSliders()
         this.menuWindows.menu.removeAll();
-        getWorkspaceWindowsArray().forEach(function(workspace, i) {
+        getWorkspaceWindowsArray().forEach((workspace, i) => {
             if (i > 0) {
                 this.menuWindows.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
             }
 
             // Populate window list on submenu
-            workspace.windows.forEach(function(window) {
+            workspace.windows.forEach((window) => {
                 let winMenuItem = new PopupMenu.PopupMenuItem(spliceTitle(window.get_title()));
-                winMenuItem.connect("activate", Lang.bind(this, function() {
+                winMenuItem.connect("activate", () => {
                     this.preview.window = window;
                     this.preview.show();
-                }));
+                });
 
                 this.menuWindows.menu.addMenuItem(winMenuItem);
-            }, this);
-        }, this);
-    },
+            });
+        });
+    }
 
-    enable: function() {
+    enable() {
 
         // Add icon
         this.icon = new St.Icon({
@@ -166,13 +163,13 @@ var WindowCornerIndicator = new Lang.Class({
             hover: false,
             reactive: true
         });
-        this.menuIsEnabled.connect("toggled", Lang.bind(this, this._onMenuIsEnabled));
+        this.menuIsEnabled.connect("toggled", (...params) => this._onMenuIsEnabled(...params));
         this.menu.addMenuItem(this.menuIsEnabled);
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
         // 1.5 Activate Mirrored window
         this.menuActivate = new PopupMenu.PopupMenuItem("Activate");
-        this.menuActivate.connect("activate", Lang.bind(this, this._onWindowActivate));
+        this.menuActivate.connect("activate", (...params) => this._onWindowActivate(...params));
         this.menu.addMenuItem(this.menuActivate);
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
@@ -190,7 +187,7 @@ var WindowCornerIndicator = new Lang.Class({
 
         // 3b, Zoom slider
         this.menuZoom = new PopupSliderMenuItem(false, DEFAULT_ZOOM, MIN_ZOOM, MAX_ZOOM, 0.005); // slider step: 0.5%
-        this.menuZoom.connect("value-changed", Lang.bind(this, this._onZoomChanged));
+        this.menuZoom.connect("value-changed", (...params) => this._onZoomChanged(...params));
         this.menu.addMenuItem(this.menuZoom);
 
         // 4. Crop Sliders
@@ -198,23 +195,23 @@ var WindowCornerIndicator = new Lang.Class({
         this.menu.addMenuItem(this.menuCrop);
 
         this.menuTopCrop = new PopupSliderMenuItem("Top", DEFAULT_CROP_RATIO, 0.0, MAX_CROP_RATIO);
-        this.menuTopCrop.connect("value-changed", Lang.bind(this, this._onTopCropChanged));
+        this.menuTopCrop.connect("value-changed", (...params) => this._onTopCropChanged(...params));
         this.menuCrop.menu.addMenuItem(this.menuTopCrop);
 
         this.menuLeftCrop = new PopupSliderMenuItem("Left", DEFAULT_CROP_RATIO, 0.0, MAX_CROP_RATIO);
-        this.menuLeftCrop.connect("value-changed", Lang.bind(this, this._onLeftCropChanged));
+        this.menuLeftCrop.connect("value-changed", (...params) => this._onLeftCropChanged(...params));
         this.menuCrop.menu.addMenuItem(this.menuLeftCrop);
 
         this.menuRightCrop = new PopupSliderMenuItem("Right", DEFAULT_CROP_RATIO, 0.0, MAX_CROP_RATIO);
-        this.menuRightCrop.connect("value-changed", Lang.bind(this, this._onRightCropChanged));
+        this.menuRightCrop.connect("value-changed", (...params) => this._onRightCropChanged(...params));
         this.menuCrop.menu.addMenuItem(this.menuRightCrop);
 
         this.menuBottomCrop = new PopupSliderMenuItem("Bottom", DEFAULT_CROP_RATIO, 0.0, MAX_CROP_RATIO);
-        this.menuBottomCrop.connect("value-changed", Lang.bind(this, this._onBottomCropChanged));
+        this.menuBottomCrop.connect("value-changed", (...params) => this._onBottomCropChanged(...params));
         this.menuCrop.menu.addMenuItem(this.menuBottomCrop);
 
         this.menuClearCrop = new PopupMenu.PopupMenuItem("Clear");
-        this.menuClearCrop.connect("activate", Lang.bind(this, this._onClearCropActivate));
+        this.menuClearCrop.connect("activate", (...params) => this._onClearCropActivate(...params));
         this.menuCrop.menu.addMenuItem(this.menuClearCrop);
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
@@ -224,31 +221,31 @@ var WindowCornerIndicator = new Lang.Class({
         this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
         this.menuTopRightCorner = new PopupMenu.PopupMenuItem("");
-        this.menuTopRightCorner.connect("activate", Lang.bind(this, this._onCornerActivate, 1));
+        this.menuTopRightCorner.connect("activate", (...params) => this._onCornerActivate(...params, 1));
         this.menuCorner.menu.addMenuItem(this.menuTopRightCorner);
 
         this.menuBottomRightCorner = new PopupMenu.PopupMenuItem("");
-        this.menuBottomRightCorner.connect("activate", Lang.bind(this, this._onCornerActivate, 2));
+        this.menuBottomRightCorner.connect("activate", (...params) => this._onCornerActivate(...params, 2));
         this.menuCorner.menu.addMenuItem(this.menuBottomRightCorner);
 
         this.menuBottomLeftCorner = new PopupMenu.PopupMenuItem("");
-        this.menuBottomLeftCorner.connect("activate", Lang.bind(this, this._onCornerActivate, 3));
+        this.menuBottomLeftCorner.connect("activate", (...params) => this._onCornerActivate(...params, 3));
         this.menuCorner.menu.addMenuItem(this.menuBottomLeftCorner);
 
         this.menuTopLeftCorner = new PopupMenu.PopupMenuItem("");
-        this.menuTopLeftCorner.connect("activate", Lang.bind(this, this._onCornerActivate, 0));
+        this.menuTopLeftCorner.connect("activate", (...params) => this._onCornerActivate(...params, 0));
         this.menuCorner.menu.addMenuItem(this.menuTopLeftCorner);
 
         // 6. Settings
         this.menuSettings = new PopupMenu.PopupMenuItem("Settings");
-        this.menuSettings.connect("activate", Lang.bind(this, this._onSettings));
+        this.menuSettings.connect("activate", (...params) => this._onSettings(...params));
         this.menu.addMenuItem(this.menuSettings);
 
-        this.actor.connect("enter-event", Lang.bind(this, this._onUserTriggered));
+        this.actor.connect("enter-event", (...params) => this._onUserTriggered(...params));
 
-    },
+    }
 
-    disable: function() {
+    disable() {
         this.menu.removeAll();
     }
 });

--- a/window-corner-preview@fabiomereu.it/indicator.js
+++ b/window-corner-preview@fabiomereu.it/indicator.js
@@ -105,8 +105,8 @@ var WindowCornerIndicator = GObject.registerClass(class WindowCornerIndicator ex
     // Update windows list and other menus before menu pops up
     _onUserTriggered() {
         this.menuIsEnabled.setToggleState(this.preview.visible);
-        this.menuIsEnabled.actor.reactive = this.preview.window;
-        this.menuActivate.actor.visible = this.preview.visible;
+        this.menuIsEnabled.reactive = this.preview.window;
+        this.menuActivate.visible = this.preview.visible;
         this.menuActivate.label.set_text(
             ["◪", "⬕", "◩", "⬔"][this.preview.corner] + " " +
             spliceTitle(this.preview.window && this.preview.window.get_title())
@@ -154,7 +154,7 @@ var WindowCornerIndicator = GObject.registerClass(class WindowCornerIndicator ex
             icon_name: "face-monkey-symbolic",
             style_class: "system-status-icon"
         });
-        this.actor.add_actor(this.icon);
+        this.add_actor(this.icon);
 
         // Prepare Menu...
 
@@ -241,7 +241,7 @@ var WindowCornerIndicator = GObject.registerClass(class WindowCornerIndicator ex
         this.menuSettings.connect("activate", (...params) => this._onSettings(...params));
         this.menu.addMenuItem(this.menuSettings);
 
-        this.actor.connect("enter-event", (...params) => this._onUserTriggered(...params));
+        this.connect("enter-event", (...params) => this._onUserTriggered(...params));
 
     }
 

--- a/window-corner-preview@fabiomereu.it/metadata.json
+++ b/window-corner-preview@fabiomereu.it/metadata.json
@@ -5,7 +5,7 @@
   "settings-schema": "org.gnome.shell.extensions.window-corner-preview",
   "gettext-domain": "gnome-shell-extensions",
   "shell-version": [
-    "3.32"
+    "3.34"
   ],
   "url": "https://github.com/medenagan/window-corner-preview",
   "uuid": "window-corner-preview@fabiomereu.it",

--- a/window-corner-preview@fabiomereu.it/polygnome.js
+++ b/window-corner-preview@fabiomereu.it/polygnome.js
@@ -4,17 +4,15 @@
 // Global modules
 const Meta = imports.gi.Meta;
 
-// This is wrapper to maintain compatibility with GNOME-Shell 3.30+ as well as
-// previous versions.
 var DisplayWrapper = {
     getScreen() {
-        return global.screen || global.display;
+        return global.display;
     },
     getWorkspaceManager() {
-        return global.screen || global.workspace_manager;
+        return global.workspace_manager;
     },
     getMonitorManager() {
-        return global.screen || Meta.MonitorManager.get();
+        return Meta.MonitorManager.get();
     }
 };
 

--- a/window-corner-preview@fabiomereu.it/polygnome.js
+++ b/window-corner-preview@fabiomereu.it/polygnome.js
@@ -7,13 +7,13 @@ const Meta = imports.gi.Meta;
 // This is wrapper to maintain compatibility with GNOME-Shell 3.30+ as well as
 // previous versions.
 var DisplayWrapper = {
-    getScreen: function() {
+    getScreen() {
         return global.screen || global.display;
     },
-    getWorkspaceManager: function() {
+    getWorkspaceManager() {
         return global.screen || global.workspace_manager;
     },
-    getMonitorManager: function() {
+    getMonitorManager() {
         return global.screen || Meta.MonitorManager.get();
     }
 };

--- a/window-corner-preview@fabiomereu.it/popupSliderMenuItem.js
+++ b/window-corner-preview@fabiomereu.it/popupSliderMenuItem.js
@@ -1,7 +1,6 @@
 "use strict";
 
 // Global modules
-const Lang = imports.lang;
 const St = imports.gi.St;
 const Slider = imports.ui.slider;
 const PopupMenu = imports.ui.popupMenu;
@@ -15,13 +14,7 @@ const Bundle = Me.imports.bundle;
 const normalizeRange = Bundle.normalizeRange;
 const deNormalizeRange = Bundle.deNormalizeRange;
 
-/*
-var PopupSliderMenuItem = new Lang.Class({
-    Name: "WindowCornerPreview.PopupSliderMenuItem",
-    Extends: PopupMenu.PopupBaseMenuItem,
-*/
-
-var PopupSliderMenuItem = class extends PopupMenu.PopupBaseMenuItem {
+var PopupSliderMenuItem = class PopupSliderMenuItem extends PopupMenu.PopupBaseMenuItem {
 
     constructor(text, value, min, max, step, params) {
 
@@ -45,14 +38,14 @@ var PopupSliderMenuItem = class extends PopupMenu.PopupBaseMenuItem {
         this.value = this.defaultValue;
 
         // PopupSliderMenuItem emits its own value-change event which provides a normalized value
-        this.slider.connect("value-changed", Lang.bind(this, function(x) {
+        this.slider.connect("value-changed", (x) => {
             let normalValue = this.value;
             // Force the slider to set position on a stepped value (if necessary)
             if (this.step !== undefined) this.value = normalValue;
             // Don't through any event if step rounded it to the same value
             if (normalValue !== this._lastValue) this.emit("value-changed", normalValue);
             this._lastValue = normalValue;
-        }));
+        });
 
         this.actor.add(this.slider.actor, {
             expand: true,

--- a/window-corner-preview@fabiomereu.it/popupSliderMenuItem.js
+++ b/window-corner-preview@fabiomereu.it/popupSliderMenuItem.js
@@ -1,6 +1,7 @@
 "use strict";
 
 // Global modules
+const GObject = imports.gi.GObject;
 const St = imports.gi.St;
 const Slider = imports.ui.slider;
 const PopupMenu = imports.ui.popupMenu;
@@ -14,11 +15,15 @@ const Bundle = Me.imports.bundle;
 const normalizeRange = Bundle.normalizeRange;
 const deNormalizeRange = Bundle.deNormalizeRange;
 
-var PopupSliderMenuItem = class PopupSliderMenuItem extends PopupMenu.PopupBaseMenuItem {
+var PopupSliderMenuItem = GObject.registerClass({
+    Signals: {
+        'value-changed': { param_types: [GObject.TYPE_DOUBLE] }
+    },
+}, class PopupSliderMenuItem extends PopupMenu.PopupBaseMenuItem {
 
-    constructor(text, value, min, max, step, params) {
+    _init(text, value, min, max, step, params) {
 
-        super(Object.assign({}, params, {activate: false}));
+        super._init(Object.assign({}, params, {activate: false}));
 
         this.min = (min !== undefined ? min : 0.0);
         this.max = (max !== undefined ? max : 1.0);
@@ -31,23 +36,24 @@ var PopupSliderMenuItem = class PopupSliderMenuItem extends PopupMenu.PopupBaseM
             text: text || ""
         });
         // Setting text to false allow a little bit extra space on the left
-        if (text !== false) this.actor.add_child(this.label);
-        this.actor.label_actor = this.label;
+        if (text !== false) this.add_child(this.label);
+        this.label_actor = this.label;
 
         this.slider = new Slider.Slider(0.0);
         this.value = this.defaultValue;
 
         // PopupSliderMenuItem emits its own value-change event which provides a normalized value
-        this.slider.connect("value-changed", (x) => {
+        this.slider.connect("notify::value", (x) => {
             let normalValue = this.value;
             // Force the slider to set position on a stepped value (if necessary)
-            if (this.step !== undefined) this.value = normalValue;
+            // TODO: prevent event handler loop
+            // if (this.step !== undefined) this.value = normalValue;
             // Don't through any event if step rounded it to the same value
             if (normalValue !== this._lastValue) this.emit("value-changed", normalValue);
             this._lastValue = normalValue;
         });
 
-        this.actor.add(this.slider.actor, {
+        this.add(this.slider, {
             expand: true,
             align: St.Align.END
         });
@@ -59,6 +65,6 @@ var PopupSliderMenuItem = class PopupSliderMenuItem extends PopupMenu.PopupBaseM
 
     set value(newValue) {
         this._lastValue = normalizeRange(newValue, this.min, this.max, this.step);
-        this.slider.setValue(this._lastValue);
+        this.slider.value = this._lastValue;
     }
-}
+});

--- a/window-corner-preview@fabiomereu.it/prefs.js
+++ b/window-corner-preview@fabiomereu.it/prefs.js
@@ -1,7 +1,6 @@
 // Global modules
 const GObject = imports.gi.GObject;
 const Gtk = imports.gi.Gtk;
-const Lang = imports.lang;
 
 // Internal modules
 const ExtensionUtils = imports.misc.extensionUtils;
@@ -14,13 +13,10 @@ function init() {
     // Nothing
 }
 
-const WindowCornerPreviewPrefsWidget = new GObject.Class({
-    Name: "WindowCornerPreview.Prefs.Widget",
-    GTypeName: "WindowCornerPreviewPrefsWidget",
-    Extends: Gtk.VBox,
+var WindowCornerPreviewPrefsWidget = GObject.registerClass(class WindowCornerPreviewPrefsWidget extends Gtk.VBox {
 
-    _init: function(params) {
-        this.parent(params);
+    _init(params) {
+        super._init(params);
 
         this.margin = 24;
         this.spacing = 6;
@@ -58,7 +54,7 @@ const WindowCornerPreviewPrefsWidget = new GObject.Class({
 
         let radio = null;
 
-        behaviors.forEach(function (behavior) {
+        behaviors.forEach((behavior) => {
 
             radio = new Gtk.RadioButton({
                 active: behavior.mode === currentBehaviorMode,
@@ -67,11 +63,11 @@ const WindowCornerPreviewPrefsWidget = new GObject.Class({
                 sensitive: true
             });
 
-            radio.connect("toggled", Lang.bind(this, function(button) {
+            radio.connect("toggled", (button) => {
                 if (button.active) {
                     settings.behaviorMode = behavior.mode;
                 }
-            }));
+            });
 
             boxBehavior.add(radio);
         });
@@ -85,7 +81,7 @@ const WindowCornerPreviewPrefsWidget = new GObject.Class({
             active: settings.focusHidden
         });
 
-        checkHideOnFocus.connect("toggled", function(button) {
+        checkHideOnFocus.connect("toggled", (button) => {
             settings.focusHidden = button.active;
         });
 
@@ -100,14 +96,14 @@ const WindowCornerPreviewPrefsWidget = new GObject.Class({
             "<i>Use</i> <b>LEFT</b>, <b>MIDDLE</b> <i>or</i> <b>RIGHT</b> <i>button to move it</i>",
             "<b>SHIFT</b> + <b>CLICK</b> <i>to activate the mirrored window</i>",
             "<u><i>" + Me.metadata.url + "</i></u>" // github
-        ].forEach(function(label) {
+        ].forEach((label) => {
             this.add(new Gtk.Label({
                 label: label,
                 use_markup: true,
                 xalign: 1.0,
                 yalign: 0.0
             }));
-        }, this);
+        });
     }
 });
 

--- a/window-corner-preview@fabiomereu.it/prefs.js
+++ b/window-corner-preview@fabiomereu.it/prefs.js
@@ -95,7 +95,7 @@ var WindowCornerPreviewPrefsWidget = GObject.registerClass(class WindowCornerPre
             "<i>Keep pressed</i> <b>SHIFT</b> <i>to prevent it from disappearing</i>",
             "<i>Use</i> <b>LEFT</b>, <b>MIDDLE</b> <i>or</i> <b>RIGHT</b> <i>button to move it</i>",
             "<b>SHIFT</b> + <b>CLICK</b> <i>to activate the mirrored window</i>",
-            "<u><i>" + Me.metadata.url + "</i></u>" // github
+            `<a href="${Me.metadata.url}">${Me.metadata.url}</a>` // github
         ].forEach((label) => {
             this.add(new Gtk.Label({
                 label: label,

--- a/window-corner-preview@fabiomereu.it/preview.js
+++ b/window-corner-preview@fabiomereu.it/preview.js
@@ -1,7 +1,6 @@
 "use strict";
 
 // Global modules
-const Lang = imports.lang;
 const Main = imports.ui.main;
 const St = imports.gi.St;
 const Tweener = imports.ui.tweener;
@@ -66,11 +65,9 @@ const BEHAVIOR_AUTOHIDE = "autohide";
 const BEHAVIOR_LIST = [BEHAVIOR_SEETHROUGH, BEHAVIOR_AUTOHIDE];
 const DEFAULT_BEHAVIOR = BEHAVIOR_SEETHROUGH;
 
-var WindowCornerPreview = new Lang.Class({
+var WindowCornerPreview = class WindowCornerPreview {
 
-    Name: "WindowCornerPreview.preview",
-
-    _init: function() {
+    constructor() {
 
         this._corner = DEFAULT_CORNER;
         this._zoom = DEFAULT_ZOOM;
@@ -93,9 +90,9 @@ var WindowCornerPreview = new Lang.Class({
         this._environmentSignals = new SignalConnector();
 
         this._outsideArea = new SensitiveArea();
-    },
+    }
 
-    _onClick: function(actor, event) {
+    _onClick(actor, event) {
         let button = event.get_button();
         let state = event.get_state();
 
@@ -120,9 +117,9 @@ var WindowCornerPreview = new Lang.Class({
             }
             this.emit("corner-changed");
         }
-    },
+    }
 
-    _getRectangle: function() {
+    _getRectangle() {
         if (! this._container)
             return new Rectangle();
 
@@ -130,9 +127,9 @@ var WindowCornerPreview = new Lang.Class({
         const [width, height] = this._container.get_transformed_size();
 
         return new Rectangle(x, y, width, height);
-    },
+    }
 
-    _onScroll: function(actor, event) {
+    _onScroll(actor, event) {
         let scroll_direction = event.get_scroll_direction();
 
         let direction;
@@ -216,9 +213,9 @@ var WindowCornerPreview = new Lang.Class({
             this[deltaMinimum.property] += deltaMinimum.direction * SCROLL_CROP_STEP;
             this.emit("crop-changed");
         }
-    },
+    }
 
-    _onEnter: function(actor, event) {
+    _onEnter(actor, event) {
         let [x, y, state] = global.get_pointer();
 
         // SHIFT: ignore standard behavior
@@ -242,9 +239,9 @@ var WindowCornerPreview = new Lang.Class({
                 transition: "easeOutQuad"
             });
         }
-    },
+    }
 
-    _onLeave: function() {
+    _onLeave() {
 
         if (this._behaviorMode === BEHAVIOR_AUTOHIDE) {
             this._autohidden = false;
@@ -257,21 +254,21 @@ var WindowCornerPreview = new Lang.Class({
                 transition: "easeOutQuad"
             });
         }
-    },
+    }
 
-    _onParamsChange: function() {
+    _onParamsChange() {
         // Zoom or crop properties changed
         if (this.enabled) this._setThumbnail();
-    },
+    }
 
-    _onWindowUnmanaged: function() {
+    _onWindowUnmanaged() {
         this.disable();
         this._window = null;
         // gnome-shell --replace will cause this event too
         this.emit("window-changed", null);
-    },
+    }
 
-    _adjustVisibility: function(options) {
+    _adjustVisibility(options) {
         options = options || {};
 
         /*
@@ -337,34 +334,34 @@ var WindowCornerPreview = new Lang.Class({
                 opacity: calculatedOpacity,
                 time: TWEEN_TIME_SHORT,
                 transition: "easeOutQuad",
-                onComplete: Lang.bind(this, function() {
+                onComplete: () => {
                     this._container.visible = calculatedVisibility;
                     this._container.reactive = true;
                     if (options.onComplete) options.onComplete();
-                })
+                }
             });
         }
-    },
+    }
 
-    _onNotifyFocusWindow: function() {
+    _onNotifyFocusWindow() {
         this._adjustVisibility();
-    },
+    }
 
-    _onOverviewShowing: function() {
+    _onOverviewShowing() {
         this._adjustVisibility();
-    },
+    }
 
-    _onOverviewHiding: function() {
+    _onOverviewHiding() {
         this._adjustVisibility();
-    },
+    }
 
-    _onMonitorsChanged: function() {
+    _onMonitorsChanged() {
         // TODO multiple monitors issue, the preview doesn't stick to the right monitor
         log("Monitors changed");
-    },
+    }
 
     // Align the preview along the chrome area
-    _setPosition: function() {
+    _setPosition() {
 
         if (! this._container) {
             return;
@@ -403,10 +400,10 @@ var WindowCornerPreview = new Lang.Class({
                 posY = rectChrome.y1;
         }
         this._container.set_position(posX, posY);
-    },
+    }
 
     // Create a window thumbnail and adds it to the container
-    _setThumbnail: function() {
+    _setThumbnail() {
 
         if (! this._container) return;
 
@@ -490,7 +487,7 @@ var WindowCornerPreview = new Lang.Class({
         this._container.add_actor(thumbnail);
 
         this._setPosition();
-    },
+    }
 
     // xCrop properties normalize their opposite counterpart, so that margins won't ever overlap
     set leftCrop(value) {
@@ -499,59 +496,59 @@ var WindowCornerPreview = new Lang.Class({
         // Decrease the opposite margin if necessary
         this._rightCrop = Math.min(this._rightCrop, MAX_CROP_RATIO - this._leftCrop);
         this._onParamsChange();
-    },
+    }
 
     set rightCrop(value) {
         this._rightCrop = Math.min(MAX_CROP_RATIO, Math.max(0.0, value));
         this._leftCrop = Math.min(this._leftCrop, MAX_CROP_RATIO - this._rightCrop);
         this._onParamsChange();
-    },
+    }
 
     set topCrop(value) {
         this._topCrop = Math.min(MAX_CROP_RATIO, Math.max(0.0, value));
         this._bottomCrop = Math.min(this._bottomCrop, MAX_CROP_RATIO - this._topCrop);
         this._onParamsChange();
-    },
+    }
 
     set bottomCrop(value) {
         this._bottomCrop = Math.min(MAX_CROP_RATIO, Math.max(0.0, value));
         this._topCrop = Math.min(this._topCrop, MAX_CROP_RATIO - this._bottomCrop);
         this._onParamsChange();
-    },
+    }
 
     get leftCrop() {
         return this._leftCrop;
-    },
+    }
 
     get rightCrop() {
         return this._rightCrop;
-    },
+    }
 
     get topCrop() {
         return this._topCrop;
-    },
+    }
 
     get bottomCrop() {
         return this._bottomCrop;
-    },
+    }
 
     set zoom(value) {
         this._zoom = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, value));
         this._onParamsChange();
-    },
+    }
 
     get zoom() {
         return this._zoom;
-    },
+    }
 
     set focusHidden(value) {
         this._focusHidden = !!value;
         this._adjustVisibility();
-    },
+    }
 
     get focusHidden() {
         return this._focusHidden;
-    },
+    }
 
     set behaviorMode(value) {
         if (BEHAVIOR_LIST.indexOf(value) > -1) {
@@ -562,60 +559,60 @@ var WindowCornerPreview = new Lang.Class({
         else {
             logError(new Error(value), "Preview.behaviorMode: type mismatch");
         }
-    },
+    }
 
     get behaviorMode() {
         return this._behaviorMode || DEFAULT_BEHAVIOR;
-    },
+    }
 
     set corner(value) {
         this._corner = (value %= 4) < 0 ? (value + 4) : (value);
         this._setPosition();
-    },
+    }
 
     get corner() {
         return this._corner;
-    },
+    }
 
     get enabled() {
         return !!this._container;
-    },
+    }
 
     get visible() {
         return this._container && this._window && this._naturalVisibility;
-    },
+    }
 
-    show: function(onComplete) {
+    show(onComplete) {
         this._naturalVisibility = true;
         this._adjustVisibility({
             onComplete: onComplete
         });
-    },
+    }
 
-    hide: function(onComplete) {
+    hide(onComplete) {
         this._naturalVisibility = false;
         this._adjustVisibility({
             onComplete: onComplete
         });
-    },
+    }
 
-    toggle: function(onComplete) {
+    toggle(onComplete) {
         this._naturalVisibility = !this._naturalVisibility;
         this._adjustVisibility({
             onComplete: onComplete
         });
-    },
+    }
 
-    passAway: function() {
+    passAway() {
         this._naturalVisibility = false;
         this._adjustVisibility({
-            onComplete: Lang.bind(this, this.disable)
+            onComplete: () => this.disable()
         });
-    },
+    }
 
     get window() {
         return this._window;
-    },
+    }
 
     set window(metawindow) {
 
@@ -626,28 +623,28 @@ var WindowCornerPreview = new Lang.Class({
         this._window = metawindow;
 
         if (metawindow) {
-            this._windowSignals.tryConnect(metawindow, "unmanaged", Lang.bind(this, this._onWindowUnmanaged));
+            this._windowSignals.tryConnect(metawindow, "unmanaged", (...params) => this._onWindowUnmanaged(...params));
             // Version 3.10 does not support size-changed
-            this._windowSignals.tryConnect(metawindow, "size-changed", Lang.bind(this, this._setThumbnail));
-            this._windowSignals.tryConnect(metawindow, "notify::maximized-vertically", Lang.bind(this, this._setThumbnail));
-            this._windowSignals.tryConnect(metawindow, "notify::maximized-horizontally", Lang.bind(this, this._setThumbnail));
+            this._windowSignals.tryConnect(metawindow, "size-changed", (...params) => this._setThumbnail(...params));
+            this._windowSignals.tryConnect(metawindow, "notify::maximized-vertically", (...params) => this._setThumbnail(...params));
+            this._windowSignals.tryConnect(metawindow, "notify::maximized-horizontally", (...params) => this._setThumbnail(...params));
         }
 
         this._setThumbnail();
 
         this.emit("window-changed", metawindow);
-    },
+    }
 
-    enable: function() {
+    enable() {
 
         if (this._container) return;
 
         let isSwitchingWindow = this.enabled;
 
-        this._environmentSignals.tryConnect(Main.overview, "showing", Lang.bind(this, this._onOverviewShowing));
-        this._environmentSignals.tryConnect(Main.overview, "hiding", Lang.bind(this, this._onOverviewHiding));
-        this._environmentSignals.tryConnect(global.display, "notify::focus-window", Lang.bind(this, this._onNotifyFocusWindow));
-        this._environmentSignals.tryConnect(DisplayWrapper.getMonitorManager(), "monitors-changed", Lang.bind(this, this._onMonitorsChanged));
+        this._environmentSignals.tryConnect(Main.overview, "showing", (...params) => this._onOverviewShowing(...params));
+        this._environmentSignals.tryConnect(Main.overview, "hiding", (...params) => this._onOverviewHiding(...params));
+        this._environmentSignals.tryConnect(global.display, "notify::focus-window", (...params) => this._onNotifyFocusWindow(...params));
+        this._environmentSignals.tryConnect(DisplayWrapper.getMonitorManager(), "monitors-changed", (...params) => this._onMonitorsChanged(...params));
 
         this._container = new St.Button({
             style_class: "window-corner-preview"
@@ -655,12 +652,12 @@ var WindowCornerPreview = new Lang.Class({
         // Force content not to overlap, allowing cropping
         this._container.set_clip_to_allocation(true);
 
-        this._container.connect("enter-event", Lang.bind(this, this._onEnter));
-        this._container.connect("leave-event", Lang.bind(this, this._onLeave));
-        this._outsideArea.connect("enter-event", Lang.bind(this, this._onLeave));
+        this._container.connect("enter-event", (...params) => this._onEnter(...params));
+        this._container.connect("leave-event", (...params) => this._onLeave(...params));
+        this._outsideArea.connect("enter-event", (...params) => this._onLeave(...params));
         // Don't use button-press-event, as set_position conflicts and Gtk would react for enter and leave event of ANY item on the chrome area
-        this._container.connect("button-release-event", Lang.bind(this, this._onClick));
-        this._container.connect("scroll-event", Lang.bind(this, this._onScroll));
+        this._container.connect("button-release-event", (...params) => this._onClick(...params));
+        this._container.connect("scroll-event", (...params) => this._onScroll(...params));
 
         this._container.visible = false;
         Main.layoutManager.addChrome(this._container);
@@ -669,9 +666,9 @@ var WindowCornerPreview = new Lang.Class({
         // this._adjustVisibility({
         //      noAnimate: isSwitchingWindow
         // });
-    },
+    }
 
-    disable: function() {
+    disable() {
 
         this._windowSignals.disconnectAll();
         this._environmentSignals.disconnectAll();
@@ -683,6 +680,6 @@ var WindowCornerPreview = new Lang.Class({
         this._container.destroy();
         this._container = null;
     }
-})
+}
 
 Signals.addSignalMethods(WindowCornerPreview.prototype);

--- a/window-corner-preview@fabiomereu.it/preview.js
+++ b/window-corner-preview@fabiomereu.it/preview.js
@@ -418,7 +418,7 @@ var WindowCornerPreview = class WindowCornerPreview {
         if (! mutw) return;
 
         let windowTexture = mutw.get_texture();
-        let [windowWidth, windowHeight] = windowTexture.get_size();
+        let [windowWidth, windowHeight] = mutw.get_size();
 
         /* To crop the window texture, for now I've found that:
            1. Using a clip rect on Clutter.clone will hide the outside portion but also will KEEP the space along it
@@ -461,8 +461,8 @@ var WindowCornerPreview = class WindowCornerPreview {
             this._zoom = windowWidth / rectMonitor.width; // do NOT set this.zoom (the encapsulated prop for _zoom) or it will be looping!
         }
 
-        let thumbnail = new Clutter.Clone({ // list parameters https://www.roojs.org/seed/gir-1.2-gtk-3.0/seed/Clutter.Clone.html
-            source: windowTexture,
+        let thumbnail = new Clutter.Actor({ // list parameters https://gjs-docs.gnome.org/clutter4~4_api/clutter.actor#index-properties
+            content: windowTexture,
             reactive: false,
 
             magnification_filter: Clutter.ScalingFilter.NEAREST, //NEAREST, //TRILINEAR,

--- a/window-corner-preview@fabiomereu.it/sensitive.js
+++ b/window-corner-preview@fabiomereu.it/sensitive.js
@@ -12,15 +12,13 @@ const Shape = Me.imports.shape;
 
 const Rectangle = Shape.Rectangle;
 
-var Area = new Lang.Class({
+var Area = class Area {
 
-    Name: "WindowCornerPreview.SensitiveArea",
-
-    _init: function() {
+    constructor() {
         // Hi
-    },
+    }
 
-    _onPointerChange: function(x, y) {
+    _onPointerChange(x, y) {
         if (! this._tester) {
             return;
         }
@@ -38,11 +36,11 @@ var Area = new Lang.Class({
             this.emit("leave-event");
         }
         this._lastPosition = position;
-    },
+    }
 
     get tester() {
         return this._tester;
-    },
+    }
 
     set tester(fn) {
         // Area.tester = (x, y) => true|false
@@ -63,7 +61,7 @@ var Area = new Lang.Class({
                 const IDLE = 100;
                 this._watch = PointerWatcher.
                     getPointerWatcher().
-                    addWatch(IDLE, Lang.bind(this, this._onPointerChange));
+                    addWatch(IDLE, (...params) => this._onPointerChange(...params));
                 // Force first event
                 this._lastPosition = false;
                 const [x, y] = global.get_pointer();
@@ -75,6 +73,6 @@ var Area = new Lang.Class({
             throw new Error("Sensitive.Area.tester requires either a function or null");
         }
     }
-});
+}
 
 Signals.addSignalMethods(Area.prototype);

--- a/window-corner-preview@fabiomereu.it/settings.js
+++ b/window-corner-preview@fabiomereu.it/settings.js
@@ -1,7 +1,6 @@
 "use strict";
 
 // Global modules
-const Lang = imports.lang;
 const Signals = imports.signals;
 
 // Internal modules
@@ -20,94 +19,90 @@ var SETTING_INITIAL_BOTTOM_CROP = "initial-bottom-crop";
 var SETTING_INITIAL_CORNER = "initial-corner";
 var SETTING_LAST_WINDOW_HASH = "last-window-hash";
 
-var WindowCornerSettings = new Lang.Class({
+var WindowCornerSettings = class WindowCornerSettings {
 
-    Name: "WindowCornerPreview.settings",
-
-    _init: function() {
+    constructor() {
         this._settings = Convenience.getSettings();
-        this._settings.connect("changed", Lang.bind(this, this._onChanged));
-    },
+        this._settings.connect("changed", (...params) => this._onChanged(...params));
+    }
 
-    _onChanged: function(settings, key) {
+    _onChanged(settings, key) {
         // "my-property-name" => myPropertyName
-        const property = key.replace(/-[a-z]/g, function (az) {
-            return az.substr(1).toUpperCase();
-        });
+        const property = key.replace(/-[a-z]/g, (az) => az.substr(1).toUpperCase());
         this.emit("changed", property);
-    },
+    }
 
     get focusHidden() {
         return this._settings.get_boolean(SETTING_FOCUS_HIDDEN);
-    },
+    }
 
     set focusHidden(value) {
         this._settings.set_boolean(SETTING_FOCUS_HIDDEN, value);
-    },
+    }
 
     get initialZoom() {
         return this._settings.get_double(SETTING_INITIAL_ZOOM);
-    },
+    }
 
     set initialZoom(value) {
         this._settings.set_double(SETTING_INITIAL_ZOOM, value);
-    },
+    }
 
     get initialLeftCrop() {
         return this._settings.get_double(SETTING_INITIAL_LEFT_CROP);
-    },
+    }
 
     set initialLeftCrop(value) {
         this._settings.set_double(SETTING_INITIAL_LEFT_CROP, value);
-    },
+    }
 
     get initialRightCrop() {
         return this._settings.get_double(SETTING_INITIAL_RIGHT_CROP);
-    },
+    }
 
     set initialRightCrop(value) {
         this._settings.set_double(SETTING_INITIAL_RIGHT_CROP, value);
-    },
+    }
 
     get initialTopCrop() {
         return this._settings.get_double(SETTING_INITIAL_TOP_CROP);
-    },
+    }
 
     set initialTopCrop(value) {
         this._settings.set_double(SETTING_INITIAL_TOP_CROP, value);
-    },
+    }
 
     get initialBottomCrop() {
         return this._settings.get_double(SETTING_INITIAL_BOTTOM_CROP);
-    },
+    }
 
     set initialBottomCrop(value) {
         this._settings.set_double(SETTING_INITIAL_BOTTOM_CROP, value);
-    },
+    }
 
     get initialCorner() {
         return this._settings.get_enum(SETTING_INITIAL_CORNER);
-    },
+    }
 
     set initialCorner(value) {
         this._settings.set_enum(SETTING_INITIAL_CORNER, value);
-    },
+    }
 
     get behaviorMode() {
         return this._settings.get_string(SETTING_BEHAVIOR_MODE);
-    },
+    }
 
     set behaviorMode(value) {
         this._settings.set_string(SETTING_BEHAVIOR_MODE, value);
-    },
+    }
 
     get lastWindowHash() {
         return this._settings.get_string(SETTING_LAST_WINDOW_HASH);
-    },
+    }
 
     set lastWindowHash(value) {
         this._settings.set_string(SETTING_LAST_WINDOW_HASH, value);
     }
-});
+}
 
 Signals.addSignalMethods(WindowCornerSettings.prototype);

--- a/window-corner-preview@fabiomereu.it/shape.js
+++ b/window-corner-preview@fabiomereu.it/shape.js
@@ -1,13 +1,8 @@
 "use strict";
 
-// Global modules
-const Lang = imports.lang;
+var Rectangle = class Rectangle {
 
-var Rectangle = new Lang.Class({
-
-    Name: "WindowCornerPreview.Rectangle",
-
-    _init: function() {
+    constructor() {
         let x0 = 0, y0 = 0;
         let x1 = 0, y1 = 0;
 
@@ -45,9 +40,9 @@ var Rectangle = new Lang.Class({
         this._x1 = x1;
         this._y0 = y0;
         this._y1 = y1;
-    },
+    }
 
-    offset: function() {
+    offset() {
         let dX = 0, dY = 0;
 
         if (arguments.length > 1) {
@@ -63,58 +58,58 @@ var Rectangle = new Lang.Class({
         this._y0 += dY;
         this._x1 += dX;
         this._y1 += dY;
-    },
+    }
 
-    move: function(x, y) {
+    move(x, y) {
         this._x1 += x - this._x0;
         this._y1 += y - this._y0;
         this._x0 = x;
         this._y0 = y;
-    },
+    }
 
-    toString: function() {
+    toString() {
         return "Rectangle(" +
             (+this._x0) + ", " +
             (+this._y0) + ")-(" +
             (+this._x1) + ", " +
             (+this._y1) + ")";
-    },
+    }
 
-    getXY: function() {
+    getXY() {
         return [this._x0, this._y0, this._x1, this._y1];
-    },
+    }
 
-    isPointInside: function (x, y) {
+    isPointInside (x, y) {
         return (
             x >= this._x0 &&
             x <= this._x1 &&
             y >= this._y0 &&
             y <= this._y1
         );
-    },
+    }
 
     get width() {
         return Math.abs(this._x0 - this._x1);
-    },
+    }
 
     get height() {
         return Math.abs(this._y0 - this._y1);
-    },
+    }
 
     get x0() {
         return this._x0;
-    },
+    }
 
     get y0() {
         return this._y0;
-    },
+    }
 
     get x1() {
         return this._x1;
-    },
+    }
 
     get y1() {
         return this._y1;
     }
 
-});
+}

--- a/window-corner-preview@fabiomereu.it/signaling.js
+++ b/window-corner-preview@fabiomereu.it/signaling.js
@@ -1,18 +1,13 @@
 "use strict";
 
-// Global modules
-const Lang = imports.lang;
-
 // Helper to disconnect more signals at once
-var SignalConnector = new Lang.Class({
+var SignalConnector = class SignalConnector {
 
-    Name: "WindowCornerPreview.SignalConnector",
-
-    _init: function() {
+    constructor() {
         this._connections = [];
-    },
+    }
 
-    tryConnect: function(actor, signal, callback) {
+    tryConnect(actor, signal, callback) {
         try {
             let handle = actor.connect(signal, callback);
             this._connections.push({
@@ -24,9 +19,9 @@ var SignalConnector = new Lang.Class({
         catch (e) {
             logError(e, "SignalConnector.tryConnect failed");
         }
-    },
+    }
 
-    tryConnectAfter: function(actor, signal, callback) {
+    tryConnectAfter(actor, signal, callback) {
         try {
             let handle = actor.connect_after(signal, callback);
             this._connections.push({
@@ -38,9 +33,9 @@ var SignalConnector = new Lang.Class({
         catch (e) {
             logError(e, "SignalConnector.tryConnectAfter failed");
         }
-    },
+    }
 
-    disconnectAll: function() {
+    disconnectAll() {
         for (let i = 0; i < this._connections.length; i++) {
             try {
                 let connection = this._connections[i];
@@ -54,4 +49,4 @@ var SignalConnector = new Lang.Class({
         }
         this._connections = [];
     }
-});
+}


### PR DESCRIPTION
I can now use the extension successfully on GNOME 3.34. There are still some bugs to work out, though:
* [ ] In “hide-and-seek” mode, moving a mouse cursor over the preview
* [ ] There is a ton of messages like the following in the journal. Memory management issues?
      ```
      Attempting to call back into JSAPI during the sweeping phase of GC. This is most likely caused by not destroying a Clutter actor or Gtk+ widget with ::destroy signals connected, but can also be caused by using the destroy(), dispose(), or remove() vfuncs. Because it would crash the application, it has been blocked and the JS callback not invoked.
      The offending signal was destroy on Gjs_ExtensionRow 0x2ea3600.
      ```
* [ ] Data flow causes event handler cycles. For now, I have disabled the snapping which reduces it somewhat but the handlers are still called few too many times.

Does anyone have an idea how to solve these?

#### What has been done

I had to accomodate the following GNOME Shell changes:
* Slider switched to value property instead of methods. (https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/666)
* Widgets themselves now inherit from actors. (https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/487)
* Popup menu is GObject.Class so it cannot use constructor. (https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/499)
* MetaShapedTexture no longer has get_size method, nor it can be cloned. (https://gitlab.gnome.org/GNOME/mutter/merge_requests/409)

Additionally:
* Changed the supported GNOME Shell versions to 3.34, as maintaining backwards compatibility would be too much work.
* Removed fallbacks since we do not support GNOME ≤ 3.34 any more.
